### PR TITLE
Added link to pulumi-tf-provider-cookiecutter template to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Pulumi is a multi-language and multi-cloud development platform. It lets you cre
 - [`vitobotta/pulumi-kubernetes-deployments`](https://github.com/vitobotta/pulumi-kubernetes-deployments) - Automate deployments of applications and services to K8s
 - [`localstack/pulumi-local`](https://github.com/localstack/pulumi-local) - Use Pulumi with LocalStack, easy-to-use test/mocking for cloud apps
 - [`env0`](https://www.env0.com) - Automate your Pulumi workflows with extra control over RBAC, Pull Request Automation, and other helpful features. 
+- [`tmeckel/pulumi-tf-provider-cookiecutter`](https://github.com/tmeckel/pulumi-tf-provider-cookiecutter) - A Cookiecutter template to create a Pulumi provider out of a Terraform Provider using TF Bridge
 
 ## Libraries
 


### PR DESCRIPTION
This PR contains a change to add a link to a cookiecutter template to wrap a TF provider with TF bridge